### PR TITLE
fix: update Docker image tag format in CI workflows

### DIFF
--- a/.github/workflows/ci_builddocker.yaml
+++ b/.github/workflows/ci_builddocker.yaml
@@ -34,7 +34,7 @@ jobs:
         id: version_step
         run: |
           echo "version=${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
-          echo "version_tag=ghcr.io/cesc1802/$GITHUB_REPOSITORY:${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
+          echo "version_tag=ghcr.io/$GITHUB_REPOSITORY:${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
 
       - name: Prepare Registry Names
         id: read-docker-image-identifiers

--- a/.github/workflows/ci_deploy_dev.yaml
+++ b/.github/workflows/ci_deploy_dev.yaml
@@ -42,7 +42,7 @@ jobs:
         id: version_step
         run: |
           echo "version=${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
-          echo "version_tag=ghcr.io/UpNext-SWAT-0/$GITHUB_REPOSITORY:${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
+          echo "version_tag=ghcr.io/$GITHUB_REPOSITORY:${GITHUB_REF#$"refs/tags/"}" >> $GITHUB_OUTPUT
 
       - name: Prepare Registry Names
         id: read-docker-image-identifiers


### PR DESCRIPTION
- Corrected the Docker image tag in `ci_builddocker.yaml` and `ci_deploy_dev.yaml` to use the repository name directly without hardcoding the username. This ensures consistency and flexibility across workflows.